### PR TITLE
Fix to version formatting that allows the addon to be installed properly.

### DIFF
--- a/JoinModifiersAndShapes.py
+++ b/JoinModifiersAndShapes.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Join Modifiers and Shapes",
     "author": "llealloo",
-    "version": (1, 01),
+    "version": (1, 0, 1),
     "blender": (2, 83, 0),
     "location": "View3D > Object Mode > Tool",
     "description": "Join and apply modifiers to selected objects including their shape keys",

--- a/JoinModifiersAndShapes_2_83.py.py
+++ b/JoinModifiersAndShapes_2_83.py.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Join Modifiers and Shapes",
     "author": "llealloo",
-    "version": (1, 00),
+    "version": (1, 0, 0),
     "blender": (2, 83, 0),
     "location": "View3D > Object Mode > Tool",
     "description": "Join and apply modifiers to selected objects including their shape keys",


### PR DESCRIPTION
The current version formatting prevents Blender from installing the add-on properly. This also makes it more [semver](https://semver.org/) compliant, rather than the charming, but confusing old Blender versioning. The old formatting was causing the install to fail silently and the addon would not appear in the addon list.